### PR TITLE
Need to update dependency-management-plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        depManagementVersion = "0.5.1.RELEASE"
+        depManagementVersion = "1.0.5.RELEASE"
     }
     repositories {
         mavenCentral()


### PR DESCRIPTION
The problem is a function of the versions of Gradle and Spring's dependency-management-plugin that are in use.

See the original report from the Spring guys in this Bug in Gradle 2.14-rc1 - No service of type StyledTextOutputFactory (https://discuss.gradle.org/t/bug-in-gradle-2-14-rc1-no-service-of-type-styledtextoutputfactory/17638) report. Gradle moved the StyledTextOutputFactory to an internal package at some point (for the 3.0 release), which broke dependency-management-plugin 0.5.x.

This dependency-management-plugin issue(https://github.com/spring-gradle-plugins/dependency-management-plugin/issues/87) details their making changes to address this in their 0.6.0 release.