### PR TITLE
remove jetty

### DIFF
--- a/app-webapp/build.gradle
+++ b/app-webapp/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'java'
 apply plugin: 'war'
-apply plugin: 'jetty'
 
 dependencies {
 


### PR DESCRIPTION
Seems jetty is not supported anymore.

https://docs.gradle.org/current/userguide/jetty_plugin.html

https://stackoverflow.com/questions/51979257/how-to-run-jetty-with-gradle